### PR TITLE
Allow/block lists, replies, edits and deletes.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,10 @@
 [configuration]
 string_length = 200
 max_embeds = 5
+allow_all_channels=no
+max_cached_messages=100
+allowed_channel_list=general,studio_test
+blocked_channel_list=pj_test
 
 [default_repository]
 username = zmkfirmware

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class Config():
 
         self.STRING_LENGTH = config.getint('configuration','string_length', fallback=200)
         self.MAX_EMBEDS = config.getint('configuration','max_embeds', fallback=5) # -1 is unlimited
+        self.MAX_CACHED_MESSAGES = config.getint('configuration', 'max_cached_messages', fallback=100)
         self.USERNAME = config.get('default_repository','username')
         self.REPOSITORY = config.get('default_repository','repository')
 
@@ -19,3 +20,7 @@ class Config():
             else: # use default username if it's not provided
                 username = self.USERNAME
             self.CHANNEL_OVERRIDES.update({channel:(username,repo)})
+
+        self.ALLOW_ALL_CHANNELS = config.getboolean('configuration', 'allow_all_channels', fallback=False)
+        self.CFG_ALLOWED_CHANNELS = config.get('configuration','allowed_channel_list',fallback="").split(',')
+        self.CFG_BLOCKED_CHANNELS = config.get('configuration','blocked_channel_list',fallback="").split(',')


### PR DESCRIPTION
 - Can by default allow/block from posting in all channels
 - Can now use "reply" functionality (for single embed requests only! API limitation)
 - Can now edit and delete replies to posted messages that have been changed or deleted.

My PRs should be more granular, but whatever.